### PR TITLE
Use correct machine-readable copyright file URI.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libjs-swfobject (2.2+dfsg-2) UNRELEASED; urgency=medium
+
+  * Use correct machine-readable copyright file URI.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Mon, 10 Sep 2018 22:30:41 +0100
+
 libjs-swfobject (2.2+dfsg-1) unstable; urgency=low
 
   * Initial release (Closes: #601160)

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format-Specification: http://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?op=file&rev=135
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Name: libjs-swfobject
 Maintainer: Christian Welzel <gawain@camlann.de>
 Source: http://code.google.com/p/swfobject/downloads/list


### PR DESCRIPTION
Use correct machine-readable copyright file URI.

Fixes lintian: out-of-date-copyright-format-uri
See https://lintian.debian.org/tags/out-of-date-copyright-format-uri.html for more details.
